### PR TITLE
Adds Pair class to generate list of combinations for participants

### DIFF
--- a/app/models/pair.rb
+++ b/app/models/pair.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+require "set"
+
+class Pair
+  include Comparable
+
+  def self.build_combinations(*objects)
+    objects.push(nil) if objects.size.odd?
+    objects.combination(2).map do |participant, other_participant|
+      new(participant, other_participant)
+    end
+  end
+
+  def initialize(participant, other_participant)
+    self.objects = [participant, other_participant]
+  end
+
+  def <=>(other)
+    objects.to_set <=> other.objects.to_set
+  end
+
+  def include?(object)
+    objects.include?(object)
+  end
+
+  def overlaps?(other_pair)
+    objects.any? { |object| other_pair.include?(object) }
+  end
+
+  protected
+
+  attr_accessor :objects
+end

--- a/app/models/scheduler.rb
+++ b/app/models/scheduler.rb
@@ -1,30 +1,31 @@
 # frozen_string_literal: true
 class Scheduler
 
-  def initialize(participants)
-    unless participants.size.positive?
-      raise ArgumentError, "Must provide at least one participant"
+  def initialize(pairs)
+    unless pairs.size.positive?
+      raise ArgumentError, "Must provide at least one pairing"
     end
 
-    @participants = participants
-    @participants.push(nil) if participants.size.odd?
+    @pairs = pairs
   end
 
   def schedule
-    n = participants.size
-    pivot = participants.pop
+    current_schedule = []
+    remaining_pairs = pairs.dup
 
-    pairings = (n - 1).times.map do
-      participants.rotate!
-      [[participants.first, pivot]] + (1...(n / 2)).map { |j| [participants[j], participants[n - 1 - j]] }
+    until remaining_pairs.size.zero?
+      current_pairing = remaining_pairs.pop
+      current_schedule << current_pairing
+
+      remaining_pairs.reject! do |pairing|
+        pairing.overlaps?(current_pairing)
+      end
     end
 
-    participants.push pivot unless pivot.nil?
-
-    pairings
+    current_schedule
   end
 
   private
 
-  attr_reader :participants
+  attr_reader :pairs
 end

--- a/spec/models/pair_spec.rb
+++ b/spec/models/pair_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+require "./app/models/pair"
+
+RSpec.describe Pair, ".build_combinations" do
+  let(:mo) { "Mo" }
+  let(:mary) { "Mary" }
+  let(:moffett) { "Moffett" }
+
+  context "with no participants" do
+    let(:subject) { described_class.build_combinations }
+
+    it do
+      is_expected.to be_empty
+    end
+  end
+
+  context "with one participant" do
+    let(:subject) { described_class.build_combinations(mo) }
+
+    it do
+      is_expected.to match_array(
+        [
+          Pair.new(mo, nil)
+        ]
+      )
+    end
+  end
+
+  context "with two participants" do
+    let(:subject) { described_class.build_combinations(mo, mary) }
+
+    it do
+      is_expected.to match_array(
+        [
+          Pair.new(mo, mary)
+        ]
+      )
+    end
+  end
+
+  context "with three participants" do
+    let(:subject) { described_class.build_combinations(mo, mary, moffett) }
+
+    it do
+      is_expected.to match_array(
+        [
+          Pair.new(mo, mary),
+          Pair.new(mo, moffett),
+          Pair.new(mo, nil),
+          Pair.new(mary, moffett),
+          Pair.new(mary, nil),
+          Pair.new(moffett, nil),
+        ]
+      )
+    end
+  end
+end
+
+RSpec.describe Pair, "#==" do
+  let(:mo) { "Mo" }
+  let(:mary) { "Mary" }
+  let(:moffett) { "Moffett" }
+
+  it do
+    expect(described_class.new(nil, nil)).to eq(described_class.new(nil, nil))
+  end
+
+  it do
+    expect(described_class.new(mo, mo)).to eq(described_class.new(mo, mo))
+  end
+
+  it do
+    expect(described_class.new(mo, mary)).to eq(described_class.new(mo, mary))
+  end
+
+  it do
+    expect(described_class.new(mo, mary)).to eq(described_class.new(mary, mo))
+  end
+
+  it do
+    expect(described_class.new(mo, moffett)).
+      not_to eq(described_class.new(mo, mary))
+  end
+end
+
+RSpec.describe Pair, "#include?" do
+  let(:mo) { "Mo" }
+  let(:mary) { "Mary" }
+  let(:moffett) { "Moffett" }
+
+  it { expect(described_class.new(mo, mo)).to include(mo) }
+  it { expect(described_class.new(mo, mary)).to include(mo) }
+  it { expect(described_class.new(mo, mary)).to include(mary) }
+
+  it { expect(described_class.new(mo, mary)).not_to include(moffett) }
+end
+
+RSpec.describe Pair, "#overlaps?" do
+  let(:mo) { "Mo" }
+  let(:mary) { "Mary" }
+  let(:moffett) { "Moffett" }
+
+  it do
+    expect(
+      described_class.new(mo, mo).
+        overlaps?(described_class.new(mo, mo))
+    ).to be_truthy
+  end
+
+  it do
+    expect(
+      described_class.new(mo, mary).
+        overlaps?(described_class.new(mary, moffett))
+    ).to be_truthy
+  end
+
+  it do
+    expect(
+      described_class.new(mo, mary).
+        overlaps?(described_class.new(moffett, moffett))
+    ).to be_falsey
+  end
+end

--- a/spec/models/scheduler_spec.rb
+++ b/spec/models/scheduler_spec.rb
@@ -1,58 +1,52 @@
 # frozen_string_literal: true
+require "./app/models/pair"
 require "./app/models/scheduler"
 
 RSpec.describe Scheduler, ".initialize" do
   let(:mo) { "Mo" }
   let(:mary) { "Mary" }
+  let(:pairs) { Pair.build_combinations(mo, mary) }
 
   it do
     expect { described_class.new([]) }.to raise_error(
       ArgumentError,
-      "Must provide at least one participant"
+      "Must provide at least one pairing"
     )
   end
 
   it do
-    expect { described_class.new([mo, mary]) }.not_to raise_error
+    expect { described_class.new(pairs) }.not_to raise_error
   end
 end
 
 RSpec.describe Scheduler, "#schedule" do
   let(:mo) { "Mo" }
+  let(:mal) { "Mal" }
   let(:mary) { "Mary" }
   let(:moffett) { "Moffett" }
 
-  context "with 1 participants" do
-    let(:subject) do
-      described_class.new([mo]).schedule
-    end
-
-    it do
-      is_expected.to match_array([[[mo, nil]]])
-    end
-  end
-
-  context "with 2 participants" do
-    let(:subject) do
-      described_class.new([mo, mary]).schedule
-    end
-
-    it do
-      is_expected.to match_array([[[mo, mary]]])
-    end
-  end
-
-  context "with 3 participants" do
-    let(:subject) do
-      described_class.new([mo, mary, moffett]).schedule
-    end
+  context "with 1 pair" do
+    let(:pairs) { Pair.build_combinations(mo, mary) }
+    let(:subject) { described_class.new(pairs).schedule }
 
     it do
       is_expected.to match_array(
         [
-          [[mary, nil], [moffett, mo]],
-          [[mo, nil], [mary, moffett]],
-          [[moffett, nil], [mo, mary]]
+          Pair.new(mo, mary)
+        ]
+      )
+    end
+  end
+
+  context "with 4 pairs" do
+    let(:pairs) { Pair.build_combinations(mo, mal, mary, moffett) }
+    let(:subject) { described_class.new(pairs).schedule }
+
+    it do
+      is_expected.to match_array(
+        [
+          Pair.new(mo, mal),
+          Pair.new(mary, moffett)
         ]
       )
     end


### PR DESCRIPTION
First pass at a new scheduling logic.

A `Pair` represents a combination of two things (probably people's names) that can be passed into the scheduler to generate a single group.

The scheduler now only produces the single group rather than the full round-robin approach so that better rankings can be introduced.